### PR TITLE
remove duplicate `/` in VertexAI _embed

### DIFF
--- a/core/llm/llms/VertexAI.ts
+++ b/core/llm/llms/VertexAI.ts
@@ -445,7 +445,7 @@ class VertexAI extends BaseLLM {
     }
 
     const resp = await this.fetch(
-      new URL(this.apiBase + `/publishers/google/models/${this.model}:predict`),
+      new URL(`publishers/google/models/${this.model}:predict`, this.apiBase),
       {
         method: "POST",
         body: JSON.stringify({


### PR DESCRIPTION
Removed duplicate `/` and aligned `new URL(...` usage with the rest of the file.

## Description

When trying to embed docs I was getting 404s in the console. I reproduced the error with `curl`/`test.sh` (given below):

When using the API directly via `test.sh` on `https://europe-west4-aiplatform.googleapis.com/v1/projects/$PROJECT_ID/locations/europe-west4/publishers/google/models/text-embedding-005:predict` everything works as expected and I receive vectors.

When using the URL used by Continue VertexAI _embed `https://europe-west4-aiplatform.googleapis.com/v1/projects/$PROJECT_ID/locations/europe-west4//publishers/google/models/text-embedding-005:predict` I get a 404.
(note the duplicate `//` in the second URL)

```test.sh
#!/bin/bash

PROJECT_ID="YOUR_PROJECT_ID"

curl \
-X POST \
-H "Authorization: Bearer $(gcloud auth print-access-token)" \
-H "Content-Type: application/json" \
https://europe-west4-aiplatform.googleapis.com/v1/projects/$PROJECT_ID/locations/europe-west4/publishers/google/models/text-embedding-005:predict -d \
$'{
  "instances": [
    {
      "task_type": "CODE_RETRIEVAL_QUERY",
      "content": "Function to add two numbers"
    }
  ],
}'
```

(from https://console.cloud.google.com/vertex-ai/publishers/google/model-garden/textembedding-gecko)

I update the `new URL(...` used in `_embed(...` to reflect the way it is used in the rest of the file (apiBase as second parameter) and removed the leading `/` in the first parameters.

## Testing instructions

Embed a document, the correct URL should be used and embeddings should succeed.
